### PR TITLE
Enable Multiple Dimensions Conversion

### DIFF
--- a/src/Conversion/ToyToMidPass.cpp
+++ b/src/Conversion/ToyToMidPass.cpp
@@ -151,7 +151,7 @@ public:
         auto newrhsType = MemRefType::get({num}, rhsType.getElementType());
         std::vector<int64_t> newSize = {num};
         std::vector<int64_t> newStride = {1};
-        lhsInput = rewriter.create<memref::ReinterpretCastOp>(
+        rhsInput = rewriter.create<memref::ReinterpretCastOp>(
             loc, newrhsType, rhsInput, 0, ArrayRef(newSize),
             ArrayRef(newStride));
       }
@@ -187,7 +187,7 @@ public:
               auto loadedVectorLhs = rewriter.create<vector::LoadOp>(
                   loc, loadedEleType, lhsInput, loopIvs);
               auto loadedVectorRhs = rewriter.create<vector::LoadOp>(
-                  loc, loadedEleType, lhsInput, loopIvs);
+                  loc, loadedEleType, rhsInput, loopIvs);
               mlir::Value valueToStore = rewriter.create<LoweredBinaryOp>(
                   loc, loadedVectorLhs, loadedVectorRhs);
               rewriter.create<vector::StoreOp>(loc, valueToStore, memRef,
@@ -206,7 +206,7 @@ public:
         auto loadedLhs = rewriter.create<vector::LoadOp>(loc, loadedEleType,
                                                          lhsInput, memRefIdx);
         auto loadedRhs = rewriter.create<vector::LoadOp>(loc, loadedEleType,
-                                                         lhsInput, memRefIdx);
+                                                         rhsInput, memRefIdx);
         mlir::Value valueToStore =
             rewriter.create<LoweredBinaryOp>(loc, loadedLhs, loadedRhs);
         rewriter.create<vector::StoreOp>(loc, valueToStore, memRef, memRefIdx);

--- a/src/Conversion/ToyToMidPass.cpp
+++ b/src/Conversion/ToyToMidPass.cpp
@@ -130,6 +130,7 @@ public:
       const auto elementType = tensorType.getElementType();
       typename ToyBinaryOp::Adaptor binaryAdaptor(operands);
 
+      // Reshape high dimension memref to 1D memref
       auto lhsInput = binaryAdaptor.getLhs();
       auto lhsType =
           binaryAdaptor.getLhs().getType().template cast<ShapedType>();
@@ -157,7 +158,6 @@ public:
       }
 
       if (tensorType.getRank() > 1) {
-        // Need to reshape MemRef to 1D shape
         const int64_t length = tensorType.getNumElements();
         auto memRefType = MemRefType::get({length}, elementType);
         std::vector<int64_t> newSize = {length};

--- a/src/Conversion/ToyToMidPass.cpp
+++ b/src/Conversion/ToyToMidPass.cpp
@@ -164,22 +164,29 @@ public:
                                                  .getType()
                                                  .template cast<ShapedType>()
                                                  .getElementType());
-      MemRefType cstp =
-          MemRefType::get({1}, IntegerType::get(getContext(), 32));
-      cstp.dump();
-      // mlir::bufferization::BufferizationOptions options;
-      // FailureOr<Value> shapeBuffer = getBuffer(rewriter, {num});
-      //  auto memTp = MemRefType::get({num}, cstp);
-      //  Value vp = rewriter.create<memref::AllocaOp>(loc, memTp);
-      auto initValueAttr = IntegerAttr::get(cstp.getElementType(), num);
-      auto vtType = mlir::RankedTensorType::get({1}, cstp.getElementType());
-      auto dcst = DenseElementsAttr::get(vtType, initValueAttr);
-      dcst.dump();
-      Value vp = rewriter.create<arith::ConstantOp>(loc, dcst);
-      auto memRefType = convertTensorToMemRef(vtType);
-      vp.setType(memRefType);
-      auto a = rewriter.create<memref::ReshapeOp>(loc, tp,
-                                                  binaryAdaptor.getLhs(), vp);
+      //      MemRefType cstp =
+      //          MemRefType::get({1}, IntegerType::get(getContext(), 32));
+      //      cstp.dump();
+      //      // mlir::bufferization::BufferizationOptions options;
+      //      // FailureOr<Value> shapeBuffer = getBuffer(rewriter, {num});
+      //      //  auto memTp = MemRefType::get({num}, cstp);
+      //      //  Value vp = rewriter.create<memref::AllocaOp>(loc, memTp);
+      //      auto initValueAttr = IntegerAttr::get(cstp.getElementType(), num);
+      //      auto vtType = mlir::RankedTensorType::get({1},
+      //      cstp.getElementType()); auto dcst = DenseElementsAttr::get(vtType,
+      //      initValueAttr); dcst.dump(); Value vp =
+      //      rewriter.create<arith::ConstantOp>(loc, dcst);
+      //      //      auto memRefType = convertTensorToMemRef(vtType);
+      //      //      vp.setType(memRefType);
+      //      auto a = rewriter.create<memref::ReshapeOp>(loc, tp,
+      //                                                  binaryAdaptor.getLhs(),
+      //                                                  vp);
+      std::vector<int64_t> si = {num};
+      std::vector<int64_t> st = {1};
+      auto a = rewriter.create<memref::ReinterpretCastOp>(
+          loc, tp, binaryAdaptor.getLhs(), 0, ArrayRef(si), ArrayRef(st));
+      //      auto a = rewriter.create<memref::ReinterpretCastOp>(
+      //          loc, tp, binaryAdaptor.getLhs());
 
       // Handle 16 f64 (4 ymm) in loops
       // For example, 65 f64 are divided into 4 x 16 + 1

--- a/test_lit/Conversion/toy_to_mid_vec.mlir
+++ b/test_lit/Conversion/toy_to_mid_vec.mlir
@@ -1,7 +1,7 @@
 // RUN: toy-opt %s -convert-toy-to-mid=lowering-pattern-mode=1 | FileCheck %s
 
-// CHECK-LABEL: @convert_add_to_mid_vec_one_dim
-toy.func @convert_add_to_mid_vec_one_dim(%arg0: tensor<3xf64>, %arg1: tensor<3xf64>) {
+// CHECK-LABEL: @convert_add_to_mid_vec_3_dim
+toy.func @convert_add_to_mid_vec_3_dim(%arg0: tensor<3xf64>, %arg1: tensor<3xf64>) {
     %0 = toy.add(%arg0, %arg1) : tensor<3xf64>, tensor<3xf64> -> tensor<3xf64>
     toy.return
 
@@ -15,23 +15,71 @@ toy.func @convert_add_to_mid_vec_one_dim(%arg0: tensor<3xf64>, %arg1: tensor<3xf
     // CHECK: return
 }
 
-// CHECK-LABEL: @convert_add_to_mid_vec_two_dim
-toy.func @convert_add_to_mid_vec_two_dim(%arg0: tensor<2x3xf64>, %arg1: tensor<2x3xf64>) {
+// CHECK-LABEL: @convert_add_to_mid_vec_17_dim
+toy.func @convert_add_to_mid_vec_17_dim(%arg0: tensor<17xf64>, %arg1: tensor<17xf64>) {
+    %0 = toy.add(%arg0, %arg1) : tensor<17xf64>, tensor<17xf64> -> tensor<17xf64>
+    toy.return
+
+    // CHECK: %alloc = memref.alloc() : memref<17xf64>
+    // CHECK: affine.for %arg2 = 0 to 16 step 16 {
+    // CHECK:  %3 = vector.load %arg0[%arg2] : memref<17xf64>, vector<16xf64>
+    // CHECK:  %4 = vector.load %arg1[%arg2] : memref<17xf64>, vector<16xf64>
+    // CHECK:  %5 = arith.addf %3, %4 : vector<16xf64>
+    // CHECK:  vector.store %5, %alloc[%arg2] : memref<17xf64>, vector<16xf64>
+    // CHECK: }
+    // CHECK: %c16 = arith.constant 16 : index
+    // CHECK: %0 = vector.load %arg0[%c16] : memref<17xf64>, vector<1xf64>
+    // CHECK: %1 = vector.load %arg1[%c16] : memref<17xf64>, vector<1xf64>
+    // CHECK: %2 = arith.addf %0, %1 : vector<1xf64>
+    // CHECK: vector.store %2, %alloc[%c16] : memref<17xf64>, vector<1xf64>
+    // CHECK: memref.dealloc %alloc : memref<17xf64>
+    // CHECK: return
+}
+
+// CHECK-LABEL: @convert_add_to_mid_vec_2x3_dim
+toy.func @convert_add_to_mid_vec_2x3_dim(%arg0: tensor<2x3xf64>, %arg1: tensor<2x3xf64>) {
     %0 = toy.add(%arg0, %arg1) : tensor<2x3xf64>, tensor<2x3xf64> -> tensor<2x3xf64>
     toy.return
 
     // CHECK: %alloc = memref.alloc() : memref<2x3xf64>
+    // CHECK: %reinterpret_cast = memref.reinterpret_cast %arg0 to offset: [0], sizes: [6], strides: [1] : memref<2x3xf64> to memref<6xf64>
+    // CHECK: %reinterpret_cast_0 = memref.reinterpret_cast %arg1 to offset: [0], sizes: [6], strides: [1] : memref<2x3xf64> to memref<6xf64>
+    // CHECK: %reinterpret_cast_1 = memref.reinterpret_cast %alloc to offset: [0], sizes: [6], strides: [1] : memref<2x3xf64> to memref<6xf64>
     // CHECK: %c0 = arith.constant 0 : index
-    // %0 = vector.load %arg0[%c0, %c0] : memref<2x3xf64>, vector<2x3xf64>
-    // %1 = vector.load %arg1[%c0, %c0] : memref<2x3xf64>, vector<2x3xf64>
-    // %2 = arith.addf %0, %1 : vector<2x3xf64>
-    // vector.store %2, %alloc[%c0, %c0] : memref<2x3xf64>, vector<2x3xf64>
+    // CHECK: %0 = vector.load %reinterpret_cast[%c0] : memref<6xf64>, vector<6xf64>
+    // CHECK: %1 = vector.load %reinterpret_cast_0[%c0] : memref<6xf64>, vector<6xf64>
+    // CHECK: %2 = arith.addf %0, %1 : vector<6xf64>
+    // CHECK: vector.store %2, %reinterpret_cast_1[%c0] : memref<6xf64>, vector<6xf64>
     // CHECK: memref.dealloc %alloc : memref<2x3xf64>
     // CHECK: return
 }
 
-// CHECK-LABEL: @convert_mul_to_mid_vec_one_dim
-toy.func @convert_mul_to_mid_vec_one_dim(%arg0: tensor<3xf64>, %arg1: tensor<3xf64>) {
+// CHECK-LABEL: @convert_add_to_mid_vec_2x9_dim
+toy.func @convert_add_to_mid_vec_2x9_dim(%arg0: tensor<2x9xf64>, %arg1: tensor<2x9xf64>) {
+    %0 = toy.add(%arg0, %arg1) : tensor<2x9xf64>, tensor<2x9xf64> -> tensor<2x9xf64>
+    toy.return
+
+    // CHECK: %alloc = memref.alloc() : memref<2x9xf64>
+    // CHECK: %reinterpret_cast = memref.reinterpret_cast %arg0 to offset: [0], sizes: [18], strides: [1] : memref<2x9xf64> to memref<18xf64>
+    // CHECK: %reinterpret_cast_0 = memref.reinterpret_cast %arg1 to offset: [0], sizes: [18], strides: [1] : memref<2x9xf64> to memref<18xf64>
+    // CHECK: %reinterpret_cast_1 = memref.reinterpret_cast %alloc to offset: [0], sizes: [18], strides: [1] : memref<2x9xf64> to memref<18xf64>
+    // CHECK: affine.for %arg2 = 0 to 16 step 16 {
+    // CHECK:  %3 = vector.load %reinterpret_cast[%arg2] : memref<18xf64>, vector<16xf64>
+    // CHECK:  %4 = vector.load %reinterpret_cast_0[%arg2] : memref<18xf64>, vector<16xf64>
+    // CHECK:  %5 = arith.addf %3, %4 : vector<16xf64>
+    // CHECK:  vector.store %5, %reinterpret_cast_1[%arg2] : memref<18xf64>, vector<16xf64>
+    // CHECK: }
+    // CHECK: %c16 = arith.constant 16 : index
+    // CHECK: %0 = vector.load %reinterpret_cast[%c16] : memref<18xf64>, vector<2xf64>
+    // CHECK: %1 = vector.load %reinterpret_cast_0[%c16] : memref<18xf64>, vector<2xf64>
+    // CHECK: %2 = arith.addf %0, %1 : vector<2xf64>
+    // CHECK: vector.store %2, %reinterpret_cast_1[%c16] : memref<18xf64>, vector<2xf64>
+    // CHECK: memref.dealloc %alloc : memref<2x9xf64>
+    // CHECK: return
+}
+
+// CHECK-LABEL: @convert_mul_to_mid_vec_3_dim
+toy.func @convert_mul_to_mid_vec_3_dim(%arg0: tensor<3xf64>, %arg1: tensor<3xf64>) {
     %0 = toy.mul(%arg0, %arg1) : tensor<3xf64>, tensor<3xf64> -> tensor<3xf64>
     toy.return
 
@@ -45,17 +93,65 @@ toy.func @convert_mul_to_mid_vec_one_dim(%arg0: tensor<3xf64>, %arg1: tensor<3xf
     // CHECK: return
 }
 
-// CHECK-LABEL: @convert_mul_to_mid_vec_two_dim
-toy.func @convert_mul_to_mid_vec_two_dim(%arg0: tensor<2x3xf64>, %arg1: tensor<2x3xf64>) {
+// CHECK-LABEL: @convert_mul_to_mid_vec_17_dim
+toy.func @convert_mul_to_mid_vec_17_dim(%arg0: tensor<17xf64>, %arg1: tensor<17xf64>) {
+    %0 = toy.mul(%arg0, %arg1) : tensor<17xf64>, tensor<17xf64> -> tensor<17xf64>
+    toy.return
+
+    // CHECK: %alloc = memref.alloc() : memref<17xf64>
+    // CHECK: affine.for %arg2 = 0 to 16 step 16 {
+    // CHECK:  %3 = vector.load %arg0[%arg2] : memref<17xf64>, vector<16xf64>
+    // CHECK:  %4 = vector.load %arg1[%arg2] : memref<17xf64>, vector<16xf64>
+    // CHECK:  %5 = arith.mulf %3, %4 : vector<16xf64>
+    // CHECK:  vector.store %5, %alloc[%arg2] : memref<17xf64>, vector<16xf64>
+    // CHECK: }
+    // CHECK: %c16 = arith.constant 16 : index
+    // CHECK: %0 = vector.load %arg0[%c16] : memref<17xf64>, vector<1xf64>
+    // CHECK: %1 = vector.load %arg1[%c16] : memref<17xf64>, vector<1xf64>
+    // CHECK: %2 = arith.mulf %0, %1 : vector<1xf64>
+    // CHECK: vector.store %2, %alloc[%c16] : memref<17xf64>, vector<1xf64>
+    // CHECK: memref.dealloc %alloc : memref<17xf64>
+    // CHECK: return
+}
+
+// CHECK-LABEL: @convert_mul_to_mid_vec_2x3_dim
+toy.func @convert_mul_to_mid_vec_2x3_dim(%arg0: tensor<2x3xf64>, %arg1: tensor<2x3xf64>) {
     %0 = toy.mul(%arg0, %arg1) : tensor<2x3xf64>, tensor<2x3xf64> -> tensor<2x3xf64>
     toy.return
 
     // CHECK: %alloc = memref.alloc() : memref<2x3xf64>
+    // CHECK: %reinterpret_cast = memref.reinterpret_cast %arg0 to offset: [0], sizes: [6], strides: [1] : memref<2x3xf64> to memref<6xf64>
+    // CHECK: %reinterpret_cast_0 = memref.reinterpret_cast %arg1 to offset: [0], sizes: [6], strides: [1] : memref<2x3xf64> to memref<6xf64>
+    // CHECK: %reinterpret_cast_1 = memref.reinterpret_cast %alloc to offset: [0], sizes: [6], strides: [1] : memref<2x3xf64> to memref<6xf64>
     // CHECK: %c0 = arith.constant 0 : index
-    // %0 = vector.load %arg0[%c0, %c0] : memref<2x3xf64>, vector<2x3xf64>
-    // %1 = vector.load %arg1[%c0, %c0] : memref<2x3xf64>, vector<2x3xf64>
-    // %2 = arith.mulf %0, %1 : vector<2x3xf64>
-    // vector.store %2, %alloc[%c0, %c0] : memref<2x3xf64>, vector<2x3xf64>
+    // CHECK: %0 = vector.load %reinterpret_cast[%c0] : memref<6xf64>, vector<6xf64>
+    // CHECK: %1 = vector.load %reinterpret_cast_0[%c0] : memref<6xf64>, vector<6xf64>
+    // CHECK: %2 = arith.mulf %0, %1 : vector<6xf64>
+    // CHECK: vector.store %2, %reinterpret_cast_1[%c0] : memref<6xf64>, vector<6xf64>
     // CHECK: memref.dealloc %alloc : memref<2x3xf64>
+    // CHECK: return
+}
+
+// CHECK-LABEL: @convert_mul_to_mid_vec_4x5_dim
+toy.func @convert_mul_to_mid_vec_4x5_dim(%arg0: tensor<4x5xf64>, %arg1: tensor<4x5xf64>) {
+    %0 = toy.mul(%arg0, %arg1) : tensor<4x5xf64>, tensor<4x5xf64> -> tensor<4x5xf64>
+    toy.return
+
+    // CHECK: %alloc = memref.alloc() : memref<4x5xf64>
+    // CHECK: %reinterpret_cast = memref.reinterpret_cast %arg0 to offset: [0], sizes: [20], strides: [1] : memref<4x5xf64> to memref<20xf64>
+    // CHECK: %reinterpret_cast_0 = memref.reinterpret_cast %arg1 to offset: [0], sizes: [20], strides: [1] : memref<4x5xf64> to memref<20xf64>
+    // CHECK: %reinterpret_cast_1 = memref.reinterpret_cast %alloc to offset: [0], sizes: [20], strides: [1] : memref<4x5xf64> to memref<20xf64>
+    // CHECK: affine.for %arg2 = 0 to 16 step 16 {
+    // CHECK:  %3 = vector.load %reinterpret_cast[%arg2] : memref<20xf64>, vector<16xf64>
+    // CHECK:  %4 = vector.load %reinterpret_cast_0[%arg2] : memref<20xf64>, vector<16xf64>
+    // CHECK:  %5 = arith.mulf %3, %4 : vector<16xf64>
+    // CHECK:  vector.store %5, %reinterpret_cast_1[%arg2] : memref<20xf64>, vector<16xf64>
+    // CHECK: }
+    // CHECK: %c16 = arith.constant 16 : index
+    // CHECK: %0 = vector.load %reinterpret_cast[%c16] : memref<20xf64>, vector<4xf64>
+    // CHECK: %1 = vector.load %reinterpret_cast_0[%c16] : memref<20xf64>, vector<4xf64>
+    // CHECK: %2 = arith.mulf %0, %1 : vector<4xf64>
+    // CHECK: vector.store %2, %reinterpret_cast_1[%c16] : memref<20xf64>, vector<4xf64>
+    // CHECK: memref.dealloc %alloc : memref<4x5xf64>
     // CHECK: return
 }

--- a/test_lit/lit.site.cfg.py.in
+++ b/test_lit/lit.site.cfg.py.in
@@ -13,7 +13,7 @@ config.llvm_exe_ext = "@EXEEXT@"
 config.lit_tools_dir = "@LLVM_LIT_TOOLS_DIR@"
 config.mlir_binary_dir = "@MLIR_BINARY_DIR@"
 config.python_executable = "@Python3_EXECUTABLE@"
-config.enable_bindings_python = @MLIR_ENABLE_BINDINGS_PYTHON@
+config.enable_bindings_python = "@MLIR_ENABLE_BINDINGS_PYTHON@"
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)


### PR DESCRIPTION
Enable this feature by using ReinterpretCastOp. ReshapeOp only accepts shape size as MLIR value, although it is static one. This is interesting.
Some discussions are found in
https://discourse.llvm.org/t/rfc-reshape-ops-restructuring/3310
https://discourse.llvm.org/t/standard-memrefreshapeop-with-constant-shape/2190